### PR TITLE
Fix/make default message unnecessary in define message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/babel-plugin-react-intl",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Extracts string messages for translation from modules that use React Intl.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/babel-plugin-react-intl",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Extracts string messages for translation from modules that use React Intl.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "lint": "eslint src/",
     "clean": "rimraf lib/",
     "test": "cross-env NODE_ENV=test mocha --compilers js:@babel/register",
-    "build": "babel --watch src/ --out-dir lib/",
+    "build": "babel src/ --out-dir lib/",
+    "watch": "babel --watch src/ --out-dir lib/",
     "build:fixtures": "babel-node ./scripts/build-fixtures.js",
     "preversion": "npm run lint && npm run clean && npm run build",
     "prepublish": "npm run clean && npm run build"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint": "eslint src/",
     "clean": "rimraf lib/",
     "test": "cross-env NODE_ENV=test mocha --compilers js:@babel/register",
-    "build": "babel src/ --out-dir lib/",
+    "build": "babel --watch src/ --out-dir lib/",
     "build:fixtures": "babel-node ./scripts/build-fixtures.js",
     "preversion": "npm run lint && npm run clean && npm run build",
     "prepublish": "npm run clean && npm run build"

--- a/src/index.js
+++ b/src/index.js
@@ -326,7 +326,7 @@ export default function ({types: t}) {
                         ]),
                         opts
                     );
-
+ 
                     // Evaluate the Message Descriptor values, then store it.
                     descriptor = evaluateMessageDescriptor(descriptor, {
                         isJSXSource: false,
@@ -341,7 +341,9 @@ export default function ({types: t}) {
                         ),
                         t.objectProperty(
                             t.stringLiteral('defaultMessage'),
-                            t.stringLiteral(descriptor.defaultMessage)
+                            descriptor.defaultMessage 
+                                ? t.stringLiteral(descriptor.defaultMessage)
+                                : t.stringLiteral('')
                         ),
                     ]));
 


### PR DESCRIPTION
Allows not to set a `defaultMessage` when using the `defineMessage` function of `react-intl`.